### PR TITLE
Fix unique key console warning in CartItems

### DIFF
--- a/e-commerce-frontend/src/Components/CartItems/CartItems.jsx
+++ b/e-commerce-frontend/src/Components/CartItems/CartItems.jsx
@@ -22,7 +22,7 @@ const CartItems = () => {
 
         if(cartItems[e.id]>0)
         {
-          return  <div>
+          return  <div key={e.id}>
                     <div className="cartitems-format">
                       <img className="cartitems-product-icon" src={e.image} alt="" />
                       <p cartitems-product-title>{e.name}</p>

--- a/e-commerce-frontend/src/Components/RelatedProducts/RelatedProducts.jsx
+++ b/e-commerce-frontend/src/Components/RelatedProducts/RelatedProducts.jsx
@@ -10,7 +10,7 @@ const RelatedProducts = () => {
       <hr />
       <div className="relatedproducts-item">
         {data_product.map((item)=>{
-            return <Item id={item.id} name={item.name} image={item.image}  new_price={item.new_price} old_price={item.old_price}/>
+            return <Item key={item.id} id={item.id} name={item.name} image={item.image}  new_price={item.new_price} old_price={item.old_price}/>
         })}
       </div>
     </div>


### PR DESCRIPTION
### Problem
React was showing a console warning about unique keys in the CartItems component when rendering a list of products. Without unique keys, React cannot efficiently track list items during re-rendering.

### Solution
Added a unique `key` prop to each product item using the product's `id`. This removes the console warning and ensures proper rendering behavior.   


No other functionality was changed.